### PR TITLE
Resolve Pydantic security alerts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Utility
-pydantic==1.10
+pydantic>=1.10.13
 ipython>=8.12
 psutil>=5.9
 pyyaml>=6.0


### PR DESCRIPTION
Upgrade pydantic from 1.10 to >=1.10.13 to address the Regular Expression Denial of Service (ReDoS) vulnerability.